### PR TITLE
Accessibility improvements

### DIFF
--- a/src/components/room-components.ts
+++ b/src/components/room-components.ts
@@ -18,18 +18,9 @@ export const RoomTitle = styled.h3<{selected?: boolean}>`
   display: flex;
   //justify-content: space-between;
   align-items: center;
-  cursor: inherit;
   
   span {
     margin-left: 1rem;
-  }
-  
-  label {
-    cursor: inherit;
-  }
-  
-  input[type="checkbox"] {
-    cursor: inherit;
   }
 `
 

--- a/src/components/room-components.ts
+++ b/src/components/room-components.ts
@@ -1,20 +1,19 @@
 import styled from "styled-components";
 
-export const RoomCard = styled.div`
+export const RoomCard = styled.article`
   background-color: #1d1d1d;
   border-radius: 5px;
   overflow: hidden;
   width: 100%;
 
   &:hover {
-    cursor: pointer;
     filter: brightness(1.125) saturate(1.5);
   }
 `
 
-export const RoomTitle = styled.div`
+export const RoomTitle = styled.h3<{selected?: boolean}>`
   font-weight: bold;
-  background-color: ${props => props.role === 'alert' ? '#E9454E' : '#5B4897'};
+  background-color: ${props => props.selected ? '#E9454E' : '#5B4897'};
   padding: 0.75rem 0.75rem 0.5rem;
   display: flex;
   //justify-content: space-between;

--- a/src/components/session-room.tsx
+++ b/src/components/session-room.tsx
@@ -11,7 +11,6 @@ type SessionProps = {
     fromTime: Date
 }
 
-
 const Hosted = styled.span`
   color: #f4f2ff;
   font-size: 0.75rem;
@@ -57,27 +56,20 @@ const SessionRoom = ({session, roomNumber, fromTime}: SessionProps) => {
         setIsMarked(isMarkedSession(roomNumber, fromTime));
     })
 
-    const addAsMarked = (e) => {
-        e.preventDefault();
-        e.stopPropagation();
-        console.log('adding');
+    const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+      setIsMarked(e.target.checked);
+      if (e.target.checked) {
         addMarkedSession(roomNumber, fromTime);
-        setIsMarked(true);
-    }
-
-    const removeAsMarked = (e) => {
-        e.preventDefault();
-        e.stopPropagation();
-        console.log('removing');
+      } else {
         removeMarkedSession(roomNumber, fromTime);
-        setIsMarked(false);
+      }
     }
 
     const id = `${session.roomNumber}${fromTime.getTime()}`
 
-    return <RoomCard onClick={isMarked ? removeAsMarked : addAsMarked}>
-        <RoomTitle role={isMarked ? 'alert' : 'heading'}>
-            <CheckSession id={id} type={"checkbox"} checked={isMarked}/>
+    return <RoomCard className="block-label">
+        <RoomTitle selected={isMarked}>
+            <CheckSession id={id} type={"checkbox"} checked={isMarked} onChange={onChange} />
             <label htmlFor={id}>
                 <span>Room {roomNumber}</span>
                 <Hosted>by {session.host}</Hosted>

--- a/src/components/timeslot-headline.tsx
+++ b/src/components/timeslot-headline.tsx
@@ -37,13 +37,13 @@ const calculateTimeSlotInformation = (timeslot: TimeSlot) => {
     return `${nextNote}${currentNote}`;
 }
 
-const TimeSlotHeadline = ({timeslot}: TimeslotProps) => {
+const TimeSlotHeadline = ({timeslot, id}: TimeslotProps) => {
     const sessionMarker = calculateTimeSlotInformation(timeslot);
     return <Headline>
         { !!sessionMarker ? <SessionMarker>
             <span>{sessionMarker}</span>
         </SessionMarker> : <></> }
-        <h2>
+        <h2 id={id}>
             {dayjs(timeslot.from).format('HH:mm')} to {dayjs(timeslot.to).format('HH:mm')}
         </h2>
     </Headline>

--- a/src/components/timeslot-headline.tsx
+++ b/src/components/timeslot-headline.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import styled from "styled-components";
-import * as dayjs from "dayjs";
+import dayjs from "dayjs";
 import {TimeSlot} from "../data/schedule";
 import {TimeslotProps} from "./timeslot";
 import {now} from "../data/now";
@@ -43,9 +43,9 @@ const TimeSlotHeadline = ({timeslot}: TimeslotProps) => {
         { !!sessionMarker ? <SessionMarker>
             <span>{sessionMarker}</span>
         </SessionMarker> : <></> }
-        <div>
+        <h2>
             {dayjs(timeslot.from).format('HH:mm')} to {dayjs(timeslot.to).format('HH:mm')}
-        </div>
+        </h2>
     </Headline>
 }
 

--- a/src/components/timeslot.tsx
+++ b/src/components/timeslot.tsx
@@ -4,24 +4,21 @@ import * as React from "react";
 import styled from "styled-components";
 import MainRoom from "./main-room";
 import TimeSlotHeadline from "./timeslot-headline";
+import dayjs from "dayjs";
 
 export type TimeslotProps = {
     timeslot: TimeSlot;
 }
 
 const Sessions = styled.div`
+  --min: 25ch;
+  --gap: 1rem;
+
   display: grid;
-  gap: 1rem;
-  margin: 1rem 0;
-  width: 100%;
-
-  @media (min-width: 960px) {
-    grid-template-columns: 1fr 1fr 1fr 1fr;
-  }
-
-  @media (max-width: 959px) {
-    grid-template-columns: 1fr 1fr;
-  }
+  gap: var(--gap);
+  /* min() with 100% prevents overflow
+  in extra narrow spaces */
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, var(--min)), 1fr));
 `
 
 const Timeslot = ({timeslot}: TimeslotProps) => {
@@ -29,14 +26,16 @@ const Timeslot = ({timeslot}: TimeslotProps) => {
     const renderSession = (session: Session) => {
         return <SessionRoom session={session} roomNumber={session.roomNumber} fromTime={timeslot.from} key={`r${timeslot.from.getHours()}${session.roomNumber}`}/>
     };
-    return <>
+    
+    const headlineId = `headline_${dayjs(timeslot.from).format('HH')}`;
+    return <fieldset aria-labelledby={headlineId}>
         <TimeSlotHeadline timeslot={timeslot}></TimeSlotHeadline>
         {
             timeslot.sessions && !timeslot.overarchingTopic
                 ? <Sessions>{timeslot.sessions.map(renderSession)}</Sessions>
                 : <MainRoom title={timeslot.overarchingTopic!}/>
         }
-    </>
+    </fieldset>
 }
 
 export default Timeslot;

--- a/src/components/timeslot.tsx
+++ b/src/components/timeslot.tsx
@@ -8,6 +8,7 @@ import dayjs from "dayjs";
 
 export type TimeslotProps = {
     timeslot: TimeSlot;
+    id?: string;
 }
 
 const Sessions = styled.div`
@@ -29,7 +30,7 @@ const Timeslot = ({timeslot}: TimeslotProps) => {
     
     const headlineId = `headline_${dayjs(timeslot.from).format('HH')}`;
     return <fieldset aria-labelledby={headlineId}>
-        <TimeSlotHeadline timeslot={timeslot}></TimeSlotHeadline>
+        <TimeSlotHeadline timeslot={timeslot} id={headlineId}></TimeSlotHeadline>
         {
             timeslot.sessions && !timeslot.overarchingTopic
                 ? <Sessions>{timeslot.sessions.map(renderSession)}</Sessions>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -16,15 +16,8 @@ const Wrapper = styled.main`
   align-items: center;
   margin-bottom: 2rem;
 
-  @media (min-width: 960px) {
-    width: 960px;
-    margin: 0 auto 2rem;
-  }
-
-  @media (max-width: 959px) {
-    width: calc(100% - 2rem);
-    padding: 1rem;
-  }
+  width: min(100% - 2rem, var(--container-max, 960px));
+  margin-inline: auto;
 `
 
 const Headline = styled.h1`
@@ -63,6 +56,7 @@ const ScheduleButton = styled(MainButton)`
 const Links = styled.div`
   width: 100%;
   display: flex;
+  gap: 1rem;
   justify-content: space-evenly;
 `
 

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -14,7 +14,7 @@ h2, h3, h4, h5, h6 {
 }
 
 /* make it clear clickable elements get cursor pointer */
-a, button, [tabindex], label, input[type="checkbox"], input[type="radio"] {
+a, button, [tabindex="0"], label, input[type="checkbox"], input[type="radio"] {
     cursor: pointer;
 }
 
@@ -56,7 +56,7 @@ html, body {
 
 .block-label a,
 .block-label button,
-.block-label [tabindex],
+.block-label [tabindex="0"],
 .block-label input[type="checkbox"]
 .block-label input[type="radio"] {
     position: relative;

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -1,10 +1,64 @@
+/* reset */
+
 * {
     margin: 0;
     padding: 0;
+}
+
+h1 {
+    font-size: 2em;
+}
+
+h2, h3, h4, h5, h6 {
+    font-size: inherit;
+}
+
+/* make it clear clickable elements get cursor pointer */
+a, button, [tabindex], label, input[type="checkbox"], input[type="radio"] {
+    cursor: pointer;
+}
+
+*:focus {
+    outline: 2px solid var(--outline, #fff);
+}
+
+*, *::before, *::after {
+    box-sizing: border-box;
+}
+
+fieldset {
+    display: block;
+    border: none;
+    width: 100%;
 }
 
 html, body {
     background-color: black;
     color: white;
     font-family: "Roboto Light", sans-serif;
+}
+
+/* Utility class: block-label component extends the clickable area of the label to the whole content */
+/* See: https://inclusive-components.design/cards/ by Heydon Pickering */
+
+.block-label {
+    position: relative;
+}
+
+.block-label label::after {
+    position: absolute;
+    content: '';
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+}
+
+.block-label a,
+.block-label button,
+.block-label [tabindex],
+.block-label input[type="checkbox"]
+.block-label input[type="radio"] {
+    position: relative;
+    z-index: 2;
 }


### PR DESCRIPTION
- add css resets (default to box-sizing border box, reset font-sizes for h2-h6, make it clear all clickable elements get cursor: pointer)
- group fields via fieldset eleents
- use h2 for timeslot headlines and associate it as accessible names to the fieldsets
- use h3 for rooms
- use article elements for cards
- remove `role="heading/alert"` attributes
- add block-label utility class (see: https://inclusive-components.design/cards/)
- make checkboxes keyboard-operable, use block-label utility class to extend the clickable area to the whole card
- add responsive grid with auto-fit columns
- simplify intrinsic width sizing/centering for the `<main>` element